### PR TITLE
Update for Terraform >= 0.13

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = "~> 2.0"
+    }
+  }
+}
+
 data "http" "cloudflare_ip4_addrs" {
   url = "https://www.cloudflare.com/ips-v4"
 }


### PR DESCRIPTION
> Note: Only provider configurations are inherited by child modules, not provider source or version requirements. Each module must declare its own provider requirements. This is especially important for non-HashiCorp providers.

https://www.terraform.io/docs/language/modules/develop/providers.html#implicit-provider-inheritance

Without this fix it's impossible to use this with anything above Terraform 0.12